### PR TITLE
Make ad detection more robust

### DIFF
--- a/mute_spotify_timer.sh
+++ b/mute_spotify_timer.sh
@@ -3,16 +3,16 @@
 while true; do
 	# get Spotify playing song name
 	name=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:org.mpris.MediaPlayer2.Player string:Metadata | sed -n '/title/{n;p}' | cut -d '"' -f 2`
-
+	url=`dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:org.mpris.MediaPlayer2.Player string:Metadata | sed -n '/url/{n;p}' | cut -d '"' -f 2`
 	echo $name
-
-	if [[ "$name" = *"Advertisement"* || "$name" = *"Spotify"* ]]; then
+	
+	if [[ "$name" = *"Advertisement"* || "$name" = *"Spotify"* ]] || [[ $url == *"/ad/"* ]]; then
 		echo "Muting"
-		~/spotify-muter-linux/mute_app.sh spotify mute
-		sleep 25
+		~/git/spotify-muter-linux/mute_app.sh spotify mute
+		sleep 5
 	else
 		echo "Unmuting"
-		~/spotify-muter-linux/mute_app.sh spotify unmute
+		~/git/spotify-muter-linux/mute_app.sh spotify unmute
 	fi
-	sleep 5
+	sleep 1
 done


### PR DESCRIPTION
Spotify song title in dbus does not always contain the word "Advertisement", however, the URL they fetch for an ad seems to always have the format "https://open.spotify.com/ad/###" versus "https://open.spotify.com/track/###" for a song. Therefore I made the above simple change to include another condition.

I also changed the sleep times, to be more responsive, and the process is still lightweight